### PR TITLE
Don't kill process after finish. Wait for the system to do so

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.0"
     defaultConfig {
         applicationId "com.snap.android"
         minSdkVersion 16
@@ -28,12 +28,14 @@ android {
     }
 }
 
+def supportVersion = "26.0.0-beta2"
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile "com.android.support:appcompat-v7:${supportVersion}"
+    compile "com.android.support:support-annotations:${supportVersion}"
     testCompile 'junit:junit:4.12'
     compile project(path: ':snapservices')
 }

--- a/snapservices.properties
+++ b/snapservices.properties
@@ -1,2 +1,2 @@
 # Snap Library Version
-version = 1.2.1
+version = 1.2.2

--- a/snapservices/build.gradle
+++ b/snapservices/build.gradle
@@ -6,7 +6,7 @@ description = "Snap Services Android Library "
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         minSdkVersion 16
@@ -34,7 +34,6 @@ android {
 def supportVersion = "26.0.0-beta2"
 dependencies {
     compile "com.android.support:support-annotations:${supportVersion}"
-    compile "com.android.support:appcompat-v7:${supportVersion}"
 }
 
 android.libraryVariants.all { variant ->

--- a/snapservices/consumer-proguard.pro
+++ b/snapservices/consumer-proguard.pro
@@ -56,13 +56,9 @@
 }
 
 -keep public class * extends android.app.Service
+-keep public class * extends android.content.BroadcastReceiver
 -keep public class * extends android.content.ContextWrapper
 -keepattributes InnerClasses
-
--dontwarn android.support.v4.**
--dontwarn android.support.v7.**
--dontwarn android.support.v13.**
--dontwarn android.support.graphics.**
 
 #To completely remove the logging entries and the strings inside it
 #-assumenosideeffects class com.android.snap.snapservices.logger.SnapLogger {

--- a/snapservices/src/main/java/com/android/snap/snapservices/SnapActivityManager.java
+++ b/snapservices/src/main/java/com/android/snap/snapservices/SnapActivityManager.java
@@ -400,16 +400,18 @@ class SnapActivityManager {
                 }
 
                 SnapService remove = mServiceWorkers.remove(serviceComponent);
+
+                if (remove == null) {
+                    SnapLogger.v("Service [component=" + serviceComponent + ";startId=" + startId + "] killed in the meantime.");
+                    return;
+                }
+
                 try {
                     remove.onDestroy();
                 } catch (Exception ex) {
                     SnapLogger.v("Error destroying service [component=" + serviceComponent + ";startId=" + startId + "]", ex);
                 }
-                try {
-                    remove.quit();
-                } catch (Exception ex) {
-                    SnapLogger.v("Error quitting service [component=" + serviceComponent + ";startId=" + startId + "]", ex);
-                }
+
                 SnapLogger.v("Service [component=" + serviceComponent + ";startId=" + startId + "] stopped!");
 
                 if (options.isKillSeparateProcessOnFinish() && verifyIfIsForkedProcess()) {

--- a/snapservices/src/main/java/com/android/snap/snapservices/SnapService.java
+++ b/snapservices/src/main/java/com/android/snap/snapservices/SnapService.java
@@ -125,23 +125,14 @@ public abstract class SnapService extends SnapContextWrapper {
      * <p>Do <b>NOT</b> call this method directly.</p>
      */
     public void onDestroy() {
-
+        SnapLogger.v("onDestroy called [name=" + mName + "]");
+        stopForeground();
+        mServiceLooper.quit();
     }
 
     public ISnapBinder onBind(Intent intent) {
         SnapLogger.v("onBind called [name=" + mName + "]");
         return null;
-    }
-
-    /**
-     * Called by the system to completely remove the existing thread.
-     * This is called after {@link #onDestroy()}.
-     */
-    void quit() {
-        SnapLogger.v("quit called [name=" + mName + "]");
-        stopForeground();
-        mServiceLooper.quit();
-        mThread.quit();
     }
 
     /**

--- a/snapservices/src/main/java/com/android/snap/snapservices/configuration/SnapConfigOptions.java
+++ b/snapservices/src/main/java/com/android/snap/snapservices/configuration/SnapConfigOptions.java
@@ -42,7 +42,7 @@ public class SnapConfigOptions {
 
     public static final class Builder {
 
-        private boolean killSeparateProcess = true;
+        private boolean killSeparateProcess = false;
         private int logLevel = SnapLogger.DISABLED;
 
         public Builder() {

--- a/snapservices/src/main/java/com/android/snap/snapservices/context/SnapContextWrapper.java
+++ b/snapservices/src/main/java/com/android/snap/snapservices/context/SnapContextWrapper.java
@@ -78,6 +78,7 @@ public class SnapContextWrapper extends ContextWrapper {
      *
      * <p><em>NOTE:</em>You should ALWAYS use this method when you want to generate a pending intent for a notification.</p>
      * @param intent The intent to be added into a pending intent.
+     * @param requestCode The private request code of the sender.
      * @return The PendingIntent already prepared to be delivered to a SnapService OR, to an Android Service
      * if you passed that one instead.
      * @see SnapServicesContext#generatePendingIntentForService(Context, Intent, int)

--- a/snapservices/src/main/res/values/strings.xml
+++ b/snapservices/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">SnapServices</string>
-</resources>


### PR DESCRIPTION
* increased version to 1.2.2
* the default behaviour now is to not force kill a process after it's finished
* removed the onQuit() method from the SnapServices as it serves no purpose. Moved the logic to onDestroy()
* removed unnecessary dependencies from the snapservices module